### PR TITLE
Replace Nan/Inf values in HSP/Maestro photometry

### DIFF
--- a/phot2lc
+++ b/phot2lc
@@ -337,10 +337,17 @@ ap_sizes = sorted(ap_sizes_raw)
 phot_names = [f for _,f in sorted(zip(ap_sizes_raw,phot_names_raw))]
 
 
-# Load in the Photometry for each aperture size
+# Load in the photometry data
 if psource in ['hsp','mae']:
-    phot_data = [pd.read_csv(f,header=None,sep='\\s+').iloc[:,1:].astype('float64') 
-                 for f in phot_names]
+
+    # Load data, replacing NaN/Inf values with zeroes
+    phot_data = []
+    for f in phot_names:
+        df = pd.read_csv(f,header=None,sep='\\s+').iloc[:,1:].astype('float64')
+        df.replace([np.inf, -np.inf], np.nan, inplace=True)
+        df.fillna(0.0, inplace=True)
+        phot_data.append(df)
+        
 elif psource == 'hcm':
 
     # Get column names and rows to skip


### PR DESCRIPTION
This pull request addresses Issue #5 where plotting the divided light curve was returning an error because NaN and Inf values in the raw photometry files from Maestro were resulting in an all-NaN divided light curve that could not be used to define the upper and lower bounds of the axis.

The fix here is to perform better filtering of the CCD-HSP and Maestro raw photometry when the files are first read in, replacing any NaN or Inf/-Inf values with zeroes.